### PR TITLE
Fix response on empty que pull to null, not resp error: for :https://…

### DIFF
--- a/Structs/qdb.go
+++ b/Structs/qdb.go
@@ -164,7 +164,7 @@ func (qdb *S_QDB) Pull() (*S_QMSG, error) {
 	}
 	keySplit := strings.Split(string(k), ":")
 	if len(keySplit) < 2 {
-		return nil, errors.New("empty queue")
+		return nil, nil
 	}
 	msgRes, err := qdb.MoveMsg(keySplit[1], Defs.STATUS_PENDING, Defs.STATUS_ACTIVE, "")
 	if err != nil {


### PR DESCRIPTION
…github.com/ywadi/crimsonq/issues/16
Hot Fix for RESP error on pull on empty que, return a null rather than resp error 